### PR TITLE
Update CLDR to 31

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "author": "Eric Ferraiuolo <edf@ericf.me>",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "cldr-core": "^29.0.0",
-    "cldr-dates-full": "^29.0.0",
-    "cldr-numbers-full": "^29.0.0",
+    "cldr-core": "^31.0.1",
+    "cldr-dates-full": "^31.0.1",
+    "cldr-numbers-full": "^31.0.1",
     "glob": "^5.0.1",
     "make-plural": "^2.1.3",
     "object.assign": "^4.0.3",


### PR DESCRIPTION
In CLDR v30 and v31, many Japanese sentences are corrected.