### PR TITLE
add support for short relative formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,17 @@ The data object returned from this package will have the following shape, here's
      pluralRuleFunction: [Function],
      fields:
       { year: [Object],
+        "year-short": [Object],
         month: [Object],
+        "month-short": [Object],
         day: [Object],
+        "day-short": [Object],
         hour: [Object],
+        "hour-short": [Object],
         minute: [Object],
-        second: [Object] } } }
+        "minute-short": [Object],
+        second: [Object],
+        "second-short": [Object] } } }
 ```
 
 Each field has the following shape, here's the data for English `year`:

--- a/lib/extract-relative.js
+++ b/lib/extract-relative.js
@@ -14,11 +14,17 @@ var normalizeLocale = require('./locales').normalizeLocale;
 // The set of CLDR date field names that are used in FormatJS.
 var FIELD_NAMES = [
     'year',
+    'year-short',
     'month',
+    'month-short',
     'day',
+    'day-short',
     'hour',
+    'hour-short',
     'minute',
+    'minute-short',
     'second',
+    'second-short',
 ];
 
 module.exports = function extractRelativeFields(locales) {


### PR DESCRIPTION
Exposes CLDR short relative date formats.

Examples:

`1 yr. ago`
`in 1 mo.`
`1 min. ago`
`in 30 sec.`


